### PR TITLE
Add getApplication method to ServletContextInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 	"require" : {
 		"php" : ">=5.4.0",
 		"appserver-io/lang" : "0.1.*",
-		"appserver-io-psr/http-message" : "0.2.*"
+		"appserver-io-psr/http-message" : "0.2.*",
+		"appserver-io-psr/application": "0.5.*"
 	},
 	"require-dev" : {
 		"appserver-io/build" : "0.2.*"

--- a/src/AppserverIo/Psr/Servlet/ServletContextInterface.php
+++ b/src/AppserverIo/Psr/Servlet/ServletContextInterface.php
@@ -112,7 +112,7 @@ interface ServletContextInterface
     
     /**
      * Returns the application this servlet context belongs to.
-     * 
+     *
      * @return AppserverIo\Psr\Application\ApplicationInterface
      */
     public function getApplication();

--- a/src/AppserverIo/Psr/Servlet/ServletContextInterface.php
+++ b/src/AppserverIo/Psr/Servlet/ServletContextInterface.php
@@ -109,4 +109,11 @@ interface ServletContextInterface
      * @return string The webapp base path
      */
     public function getWebappPath();
+    
+    /**
+     * Returns the application this servlet context belongs to.
+     * 
+     * @return AppserverIo\Psr\Application\ApplicationInterface
+     */
+    public function getApplication();
 }


### PR DESCRIPTION
Since people may want to be able to get the ApplicationInterface from their servlets, the ServletContextInterface should provide a getApplication method.
The normal implementation of the ServletContextInterface is the ServletManager which does provide a getApplication method.
