### PR TITLE
Generate cryptographically safe pseudo random bytes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 php:
   - 7.0
   - 5.6
-  - 5.5
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - if [[ "$TRAVIS_PHP_VERSION" < "7.0" ]]; then pecl install pthreads-2.0.10; fi
   - if [[ "$TRAVIS_PHP_VERSION" = "7.0" ]] || [[ "$TRAVIS_PHP_VERSION" > "7.0" ]]; then pecl install pthreads-3.1.6; fi
   - phpenv rehash
+  - apt-get update && apt-get install -y ant && ant dependencies-init
   - wget https://scrutinizer-ci.com/ocular.phar
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,15 @@ matrix:
   allow_failures:
     - php: 7.0
 
+addons:
+  apt:
+    packages:
+      - ant
+
 before_install:
   - if [[ "$TRAVIS_PHP_VERSION" < "7.0" ]]; then pecl install pthreads-2.0.10; fi
   - if [[ "$TRAVIS_PHP_VERSION" = "7.0" ]] || [[ "$TRAVIS_PHP_VERSION" > "7.0" ]]; then pecl install pthreads-3.1.6; fi
   - phpenv rehash
-  - apt-get update && apt-get install -y ant && ant dependencies-init
   - wget https://scrutinizer-ci.com/ocular.phar
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
 before_install:
   - if [[ "$TRAVIS_PHP_VERSION" < "7.0" ]]; then pecl install pthreads-2.0.10; fi
   - if [[ "$TRAVIS_PHP_VERSION" = "7.0" ]] || [[ "$TRAVIS_PHP_VERSION" > "7.0" ]]; then pecl install pthreads-3.1.6; fi
-  - pecl install xdebug-2.5.5
   - phpenv rehash
   - wget https://scrutinizer-ci.com/ocular.phar
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 	"require" : {
 		"php" : ">=5.4.0",
 		"appserver-io/lang" : "~3.0",
-		"appserver-io-psr/http-message" : "~1.0"
+		"appserver-io-psr/http-message" : "~1.0",
+		"ext-openssl": "*"
 	},
 	"require-dev" : {
 		"appserver-io/build" : "~1.0"

--- a/src/AppserverIo/Psr/Servlet/SessionUtils.php
+++ b/src/AppserverIo/Psr/Servlet/SessionUtils.php
@@ -42,22 +42,21 @@ class SessionUtils
     /**
      * Creates a random string with the passed length.
      *
-     * @param integer $length The string length to generate
+     * @param integer $length The byte length to generate
      *
-     * @return string The random string
+     * @return string The hex encoded random bytes
      */
     public static function generateRandomString($length = 32)
     {
-        // prepare an array with the chars used to create a random string
-        $letters = str_split('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz');
 
-        // create and return the random string
-        $bytes = '';
-        foreach (range(1, $length) as $i) {
-            $bytes = $letters[mt_rand(0, sizeof($letters) - 1)] . $bytes;
+        // generate random bytes using openssl
+        $randomBytes = openssl_random_pseudo_bytes($length, $cryptoSafe);
+
+        // make sure the generation was a) successful and b) cryptographically safe
+        if (false === $randomBytes || false === $cryptoSafe) {
+            throw new \RuntimeException('Unable to generate cryptographically safe pseudo random bytes.');
         }
 
-        // return the unique ID
-        return $bytes;
+        return bin2hex($randomBytes);
     }
 }


### PR DESCRIPTION
The previous implementation used mt_rand() in combination with an alphabet of 62 characters in order to create 'random' strings. It is not recommended to use mt_rand() for cryptographically secure purposes like generating a session identifier. 

The new implementation uses openssl_random_pseudo_bytes() with a default size of 32 bytes. An additional side effect of this is an increase in entropy from log2(62^32) ~ 190.5 bits (with default string length of 32) to 256 bits.